### PR TITLE
Fix confirm/reject buttons visibility and add proper API integration

### DIFF
--- a/CHANGES_SUMMARY.md
+++ b/CHANGES_SUMMARY.md
@@ -1,0 +1,67 @@
+# Confirm/Reject Buttons Fix Summary
+
+## Problem
+The confirm and reject buttons were not showing in the Farmer Orders UI because the frontend was checking the wrong data structure.
+
+## Root Cause
+The frontend was checking `order.status` to determine when to show buttons, but the backend API returns `actions.can_confirm` and `actions.can_reject` fields that should be used instead.
+
+## Files Changed
+
+### 1. `src/components/ConfirmRejectButtons.jsx`
+- **Changed props**: From `({ orderId, status })` to `({ orderId, actions })`
+- **Updated logic**: Now checks `actions?.can_confirm` and `actions?.can_reject` instead of `status === "paid"`
+- **Added debugging**: Console logs to help troubleshoot data issues
+- **Improved flexibility**: Handles different action combinations (confirm only, reject only, both, or none)
+
+### 2. `src/pages/FarmerOrders.jsx`
+- **Updated prop passing**: Changed from `status={order.status}` to `actions={order.actions}`
+- **Maintains existing functionality**: All other features remain unchanged
+
+### 3. `src/services/api.js`
+- **Added Authorization header**: Automatic Bearer token injection for all API requests
+- **Token source**: Reads from `localStorage.getItem('token')`
+- **Backward compatible**: Doesn't break existing functionality
+
+### 4. `src/components/__tests__/ConfirmRejectButtons.test.jsx` (New)
+- **Comprehensive tests**: Covers all button rendering scenarios
+- **Action-based logic**: Tests confirm/reject button visibility based on actions
+- **Interaction tests**: Verifies button clicks trigger correct Redux actions
+- **Loading state**: Tests button disabled state during loading
+
+## Key Features Implemented
+
+### ✅ Conditional Button Rendering
+- "Confirm" button only shows when `actions.can_confirm === true`
+- "Reject" button only shows when `actions.can_reject === true`
+- Both buttons can show simultaneously if both actions are available
+- No buttons show if neither action is available
+
+### ✅ Proper API Integration
+- Uses existing Redux async thunks (`confirmOrder`, `rejectOrder`)
+- Automatic Authorization header injection
+- Loading state management per-button
+- Error handling through existing Redux patterns
+
+### ✅ User Experience
+- Buttons disable during loading with visual feedback
+- Hover effects for better interactivity
+- Consistent styling with existing design system
+- Debug logging for troubleshooting
+
+## Testing
+Run tests with:
+```bash
+npm test src/components/__tests__/ConfirmRejectButtons.test.jsx
+```
+
+## Verification
+1. Navigate to `/farmer/orders` in your browser
+2. Check browser console for debug logs showing `actions.can_confirm` and `actions.can_reject` values
+3. Buttons should now appear based on the API response actions
+4. Clicking buttons should trigger API calls with proper Authorization headers
+
+## Next Steps
+- Verify the backend is returning the correct `actions` object in order responses
+- Test with different order states to ensure buttons appear/disappear correctly
+- Monitor console logs to confirm the data structure matches expectations

--- a/src/components/ConfirmRejectButtons.jsx
+++ b/src/components/ConfirmRejectButtons.jsx
@@ -34,11 +34,32 @@ const rejectButtonStyle = {
   boxShadow: "0 1px 3px 0 rgba(239, 68, 68, 0.3)"
 };
 
-export default function ConfirmRejectButtons({ orderId, status }) {
+export default function ConfirmRejectButtons({ orderId, actions }) {
   const dispatch = useDispatch();
   const { loading } = useSelector((state) => state.orders);
 
-  if (status !== "paid" || !orderId) return null;
+  // Debug logging to understand what data we're receiving
+  console.log('ConfirmRejectButtons debug:', {
+    orderId,
+    actions,
+    canConfirm: actions?.can_confirm,
+    canReject: actions?.can_reject
+  });
+
+  // Check if buttons should be shown based on actions from API
+  const canShowConfirm = actions?.can_confirm === true;
+  const canShowReject = actions?.can_reject === true;
+  const canShowButtons = canShowConfirm || canShowReject;
+
+  if (!canShowButtons) {
+    // Show debug info when buttons are hidden
+    console.log('Buttons hidden because:', {
+      canConfirm: actions?.can_confirm,
+      canReject: actions?.can_reject,
+      reason: !canShowConfirm && !canShowReject ? 'No actions available' : 'Missing orderId'
+    });
+    return null;
+  }
 
   return (
     <div style={containerStyle}>

--- a/src/components/__tests__/ConfirmRejectButtons.test.jsx
+++ b/src/components/__tests__/ConfirmRejectButtons.test.jsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import ConfirmRejectButtons from '../ConfirmRejectButtons';
+import ordersReducer from '../../features/orders/ordersSlice';
+
+// Mock Redux store
+const createMockStore = (initialState = {}) => {
+  return configureStore({
+    reducer: {
+      orders: ordersReducer,
+    },
+    preloadedState: initialState,
+  });
+};
+
+const mockDispatch = jest.fn();
+
+// Mock useDispatch
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
+
+describe('ConfirmRejectButtons', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not render when no actions are available', () => {
+    render(
+      <Provider store={createMockStore()}>
+        <ConfirmRejectButtons orderId="123" actions={{}} />
+      </Provider>
+    );
+    
+    expect(screen.queryByText('✓ Confirm')).not.toBeInTheDocument();
+    expect(screen.queryByText('✕ Reject')).not.toBeInTheDocument();
+  });
+
+  it('should render confirm button when can_confirm is true', () => {
+    render(
+      <Provider store={createMockStore()}>
+        <ConfirmRejectButtons orderId="123" actions={{ can_confirm: true }} />
+      </Provider>
+    );
+    
+    expect(screen.getByText('✓ Confirm')).toBeInTheDocument();
+    expect(screen.queryByText('✕ Reject')).not.toBeInTheDocument();
+  });
+
+  it('should render reject button when can_reject is true', () => {
+    render(
+      <Provider store={createMockStore()}>
+        <ConfirmRejectButtons orderId="123" actions={{ can_reject: true }} />
+      </Provider>
+    );
+    
+    expect(screen.queryByText('✓ Confirm')).not.toBeInTheDocument();
+    expect(screen.getByText('✕ Reject')).toBeInTheDocument();
+  });
+
+  it('should render both buttons when both actions are available', () => {
+    render(
+      <Provider store={createMockStore()}>
+        <ConfirmRejectButtons orderId="123" actions={{ can_confirm: true, can_reject: true }} />
+      </Provider>
+    );
+    
+    expect(screen.getByText('✓ Confirm')).toBeInTheDocument();
+    expect(screen.getByText('✕ Reject')).toBeInTheDocument();
+  });
+
+  it('should call confirmOrder when confirm button is clicked', () => {
+    render(
+      <Provider store={createMockStore()}>
+        <ConfirmRejectButtons orderId="123" actions={{ can_confirm: true }} />
+      </Provider>
+    );
+    
+    fireEvent.click(screen.getByText('✓ Confirm'));
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'orders/confirmOrder/pending', meta: { requestId: expect.any(String) } });
+  });
+
+  it('should call rejectOrder when reject button is clicked', () => {
+    render(
+      <Provider store={createMockStore()}>
+        <ConfirmRejectButtons orderId="123" actions={{ can_reject: true }} />
+      </Provider>
+    );
+    
+    fireEvent.click(screen.getByText('✕ Reject'));
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'orders/rejectOrder/pending', meta: { requestId: expect.any(String) } });
+  });
+
+  it('should disable buttons when loading', () => {
+    render(
+      <Provider store={createMockStore({ orders: { loading: true } })}>
+        <ConfirmRejectButtons orderId="123" actions={{ can_confirm: true, can_reject: true }} />
+      </Provider>
+    );
+    
+    const confirmButton = screen.getByText('✓ Confirm');
+    const rejectButton = screen.getByText('✕ Reject');
+    
+    expect(confirmButton).toBeDisabled();
+    expect(rejectButton).toBeDisabled();
+  });
+});

--- a/src/pages/FarmerOrders.jsx
+++ b/src/pages/FarmerOrders.jsx
@@ -89,7 +89,7 @@ export default function FarmerOrders() {
         <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
           {orders.map((order) => (
             <OrderCard key={order.id} order={order}>
-              <ConfirmRejectButtons orderId={order.id} status={order.status} />
+              <ConfirmRejectButtons orderId={order.id} actions={order.actions} />
             </OrderCard>
           ))}
         </div>

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -5,4 +5,18 @@ const API = axios.create({
   withCredentials: true,
 });
 
+// Add request interceptor to include Authorization header
+API.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
 export default API;


### PR DESCRIPTION
- Update ConfirmRejectButtons to use actions.can_confirm/can_reject instead of status
- Add automatic Authorization header injection for API calls
- Add comprehensive tests for button rendering and interactions
- Add debug logging for troubleshooting
- Create CHANGES_SUMMARY.md documenting all changes